### PR TITLE
Update tutorial example to use zu.fieldText.required()

### DIFF
--- a/src/content/docs/tutorials/create-your-first-crud.mdx
+++ b/src/content/docs/tutorials/create-your-first-crud.mdx
@@ -729,7 +729,7 @@ We will create a **"Project"** entity with the full CRUD (Create Read Update Del
     export const zProject = () =>
       z.object({
         id: z.string(),
-        name: zu.string.nonEmpty(z.string()),
+        name: zu.fieldText.required(),
         description: z.string().nullish(),
       });
     ```
@@ -745,7 +745,7 @@ We will create a **"Project"** entity with the full CRUD (Create Read Update Del
     export const zProject = () =>
       z.object({
         id: z.string(),
-        name: zu.string.nonEmpty(z.string()),
+        name: zu.fieldText.required(),
         description: z.string().nullish(),
       });
     ```


### PR DESCRIPTION
This PR updates the tutorial example to reflect the current zod-utils API.

The previous line in `src/features/project/schema.ts` :
  name: zu.string.nonEmpty(z.string()),
was using `zu.string`, which no longer exists in recent versions of zod-utils.
It has been replaced with:
  name: zu.fieldText.required(),


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated validation logic for the Project name field to improve consistency and robustness across the application's schema definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->